### PR TITLE
created editable textfield

### DIFF
--- a/components/document-preview.tsx
+++ b/components/document-preview.tsx
@@ -6,10 +6,13 @@ import { Download } from "lucide-react"
 import { useToast } from "@/hooks/use-toast"
 import {DocumentData} from "@/models/DocumentData";
 import { marked } from 'marked';
+import { useState } from "react"
 
 
 export default function DocumentPreview( {generatedDocument, documentData} : {generatedDocument: string, documentData: DocumentData}) {
   const { toast } = useToast()
+
+  const [editableDoc, setEditableDoc] = useState(generatedDocument)
 
     const handleDownload = () => {
     try {
@@ -35,10 +38,13 @@ export default function DocumentPreview( {generatedDocument, documentData} : {ge
     <Card className="mt-8">
       <CardHeader className="flex flex-row items-center justify-between">
         <CardTitle>Generated Document</CardTitle>
-
       </CardHeader>
       <CardContent>
-        <div className="bg-muted p-4 rounded-md whitespace-pre-wrap max-h-[500px] overflow-y-auto">{generatedDocument}</div>
+        <textarea
+          className="bg-muted p-4 rounded-md w-full max-h-[500px] min-h-[200px] overflow-y-auto resize-y"
+          defaultValue={editableDoc}
+          onChange={e => setEditableDoc(e.target.value)}
+        />
       </CardContent>
     </Card>
   )


### PR DESCRIPTION
This pull request introduces a new feature to make the generated document editable within the `DocumentPreview` component. The most important changes include adding state management for the editable document and replacing the static document display with a text area for editing.

### New Feature: Editable Document

* [`components/document-preview.tsx`](diffhunk://#diff-f6b7a7e0de9685bcfd344205ca40c00c7adfda7d5bcf9ba1affe7a891e9a539aR9-R16): Introduced a new `useState` hook to manage the state of the editable document (`editableDoc`) and initialized it with the `generatedDocument` prop.
* [`components/document-preview.tsx`](diffhunk://#diff-f6b7a7e0de9685bcfd344205ca40c00c7adfda7d5bcf9ba1affe7a891e9a539aL38-R47): Replaced the static `div` displaying the `generatedDocument` with a `textarea` element. The `textarea` allows users to edit the document, and its value is tied to the `editableDoc` state. Added an `onChange` handler to update the state whenever the text area content changes.