### PR TITLE
fix md width

### DIFF
--- a/src/components/ropa-preview.tsx
+++ b/src/components/ropa-preview.tsx
@@ -274,7 +274,7 @@ export default function RopaPreview({generatedDocument, setGeneratedDocument}: {
                 )}
                 <div className="flex items-center justify-end mt-4 gap-2">
                     <Select value={downloadFormat} onValueChange={(value: 'markdown' | 'text' | 'json' | 'pdf') => setDownloadFormat(value)}>
-                        <SelectTrigger className="w-32">
+                        <SelectTrigger className="w-40">
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent>


### PR DESCRIPTION
This pull request makes a minor UI adjustment to the `RopaPreview` component. The width of the `SelectTrigger` element for choosing the download format has been increased to improve layout and readability.

* Increased the width of the `SelectTrigger` element from `w-32` to `w-40` in `src/components/ropa-preview.tsx`.