### PR TITLE
force dynamic

### DIFF
--- a/src/app/[locale]/docs/layout.tsx
+++ b/src/app/[locale]/docs/layout.tsx
@@ -3,6 +3,8 @@ import { DocsLayout } from 'fumadocs-ui/layouts/docs';
 import { baseOptions } from '@/lib/layout.shared';
 import {RootProvider} from "fumadocs-ui/provider";
 
+export const dynamic = 'force-dynamic';
+
 // @ts-ignore
 export default function Layout({ children }: LayoutProps<'/docs'>) {
     return <RootProvider>


### PR DESCRIPTION
This pull request introduces a minor configuration change to the documentation layout. The most important update is the addition of the `dynamic` export set to `'force-dynamic'`, which ensures that the documentation pages are rendered dynamically rather than statically.

Configuration update:

* Added `export const dynamic = 'force-dynamic';` to `src/app/[locale]/docs/layout.tsx` to force dynamic rendering of documentation pages. ([src/app/[locale]/docs/layout.tsxR6-R7](diffhunk://#diff-083f61a46fa7b02b4b12fa12425c083c01cea9bfad8d1ff5461e65e868cb6dbbR6-R7))