### PR TITLE
36 fix generate pdf

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,87 @@
+# Dependencies
+node_modules
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Production builds
+.next
+out
+dist
+build
+
+# Environment files
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE and editor files
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile*
+docker-compose*
+.dockerignore
+
+# Testing
+coverage
+.nyc_output
+*.lcov
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# Documentation
+README.md
+LICENSE
+
+# Development tools
+.eslintrc*
+.prettierrc*
+jest.config.*
+*.test.js
+*.test.ts
+*.spec.js
+*.spec.ts
+
+# Temporary files
+tmp
+temp

--- a/.dockerignore
+++ b/.dockerignore
@@ -10,13 +10,6 @@ out
 dist
 build
 
-# Environment files
-.env
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
-
 # IDE and editor files
 .vscode
 .idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,30 @@
 FROM node:18
 
+# Install necessary dependencies for Puppeteer and Chromium
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  fonts-liberation \
+  libasound2 \
+  libatk-bridge2.0-0 \
+  libatk1.0-0 \
+  libcups2 \
+  libdrm2 \
+  libgbm1 \
+  libgtk-3-0 \
+  libnspr4 \
+  libnss3 \
+  libx11-xcb1 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxrandr2 \
+  xdg-utils \
+  libu2f-udev \
+  libxshmfence1 \
+  libglu1-mesa \
+  chromium \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+
 WORKDIR /app
 
 COPY package*.json ./
@@ -12,5 +37,9 @@ COPY . .
 RUN npm run build
 
 EXPOSE 3000
+
+# Puppeteer setup: Skip Chromium download and use the installed Chromium
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+ENV PUPPETEER_EXECUTABLE_PATH="/usr/bin/chromium"
 
 CMD ["npm", "start"]


### PR DESCRIPTION
This pull request improves the Docker setup for the project by adding a `.dockerignore` file and updating the `Dockerfile` to better support Puppeteer and Chromium. The main changes focus on optimizing Docker image size and ensuring compatibility with Puppeteer by installing system dependencies and configuring environment variables.

**Docker configuration improvements:**

* Added a comprehensive `.dockerignore` file to exclude unnecessary files and directories from the Docker build context, reducing image size and build time.

**Puppeteer and Chromium support:**

* Updated the `Dockerfile` to install all required system dependencies for running Puppeteer with Chromium, including fonts and libraries, and added Chromium installation.
* Configured environment variables in the `Dockerfile` to skip Puppeteer's default Chromium download and use the system-installed Chromium binary.