### PR TITLE
adjust templates to locale

### DIFF
--- a/src/components/ui/moving-banner.tsx
+++ b/src/components/ui/moving-banner.tsx
@@ -40,7 +40,7 @@ export default function MovingBanner({locale}: MovingBannerProps) {
                         {[...topRowItems, ...topRowItems].map((item, index) => (
                             <Link
                                 key={index}
-                                href="/generate"
+                                href={`/${locale}/generate`}
                                 className="flex-shrink-0 mx-2 px-4 py-2 bg-primary/10 text-primary rounded-full text-sm font-medium whitespace-nowrap  -primary/20 hover:bg-primary/20 transition-colors cursor-pointer"
                             >
                                 {item}
@@ -58,7 +58,7 @@ export default function MovingBanner({locale}: MovingBannerProps) {
                         {[...middleRowItems, ...middleRowItems].map((item, index) => (
                             <Link
                                 key={index}
-                                href="/generate"
+                                href={`/${locale}/generate`}
                                 className="flex-shrink-0 mx-2 px-4 py-2 bg-secondary text-secondary-foreground rounded-full text-sm font-medium whitespace-nowrap  hover:bg-secondary/80 transition-colors cursor-pointer"
                             >
                                 {item}
@@ -76,7 +76,7 @@ export default function MovingBanner({locale}: MovingBannerProps) {
                         {[...bottomRowItems, ...bottomRowItems].map((item, index) => (
                             <Link
                                 key={index}
-                                href="/generate"
+                                href={`/${locale}/generate`}
                                 className="flex-shrink-0 mx-2 px-4 py-2 bg-accent text-accent-foreground rounded-full text-sm font-medium whitespace-nowrap  hover:bg-accent/80 transition-colors cursor-pointer"
                             >
                                 {item}


### PR DESCRIPTION
This pull request updates the links in the `MovingBanner` component to be locale-aware. Now, each banner item will link to the localized `/generate` route based on the current `locale` prop, ensuring users are directed to the correct language version of the page.

Localization improvements:

* Updated the `href` attribute for banner items in the top, middle, and bottom rows to use `/${locale}/generate` instead of `/generate` in `src/components/ui/moving-banner.tsx`. [[1]](diffhunk://#diff-4cba6d17bd7612b01fcb71a79ad41c3be9dc8555c5893caa23de8132f43f9540L43-R43) [[2]](diffhunk://#diff-4cba6d17bd7612b01fcb71a79ad41c3be9dc8555c5893caa23de8132f43f9540L61-R61) [[3]](diffhunk://#diff-4cba6d17bd7612b01fcb71a79ad41c3be9dc8555c5893caa23de8132f43f9540L79-R79)