### PR TITLE
add AI suggestion button with tooltip for missing document title

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -21,6 +21,8 @@
     "info": "Dokumentinformationen",
     "infoTitle": "Dokumenttitel",
     "infoPlaceholder": "z.B. Mitarbeiterdatenverarbeitung, Kundenverwaltung, Marketingaktivitäten",
+    "aiSuggest": "KI-Vorschlag",
+    "aiSuggestTooltip": "Bitte geben Sie einen Dokumenttitel ein, bevor Sie KI-Vorschläge verwenden",
     "categories": "Dokumentkategorien",
     "additionalInfo": "Zusätzliche Informationen",
     "additionalInfoPlaceholder": "z.B. Besondere Sicherheitsmaßnahmen, Auftragsverarbeiter, internationale Übermittlungen...",

--- a/messages/en.json
+++ b/messages/en.json
@@ -19,6 +19,8 @@
     "info": "Document Information",
     "infoTitle": "Document Title",
     "infoPlaceholder": "e.g., Employee Data Processing, Customer Management, Marketing Activities",
+    "aiSuggest": "AI Suggest",
+    "aiSuggestTooltip": "Please enter a document title before using AI suggestions",
     "categories": "Document Categories",
     "additionalInfo": "Additional Information",
     "additionalInfoPlaceholder": "e.g., Special security measures, third-party processors, international transfers...",

--- a/src/components/ropa-form.tsx
+++ b/src/components/ropa-form.tsx
@@ -19,7 +19,6 @@ import { Sparkles } from "lucide-react";
 export default function RopaForm({setGeneratedDocument}: {setGeneratedDocument: (doc: string) => void}) {
 
     const t = useTranslations('Generate');
-
     const [documentData, setDocumentData] = useState<DocumentData>({
         id: "",
         title: "",
@@ -497,20 +496,28 @@ export default function RopaForm({setGeneratedDocument}: {setGeneratedDocument: 
 
     function AISuggestButton({ onClick, disabled, source }: { onClick: () => void, disabled: boolean, source: string }) {
         const isLoading = aiSuggestLoading[source];
+        const isTitleMissing = !documentData.title.trim();
+        const isButtonDisabled = disabled || isLoading || isAnyAiSuggestLoading;
+
         return (
-            <Button
-                variant="outline"
-                onClick={onClick}
-                disabled={disabled || isLoading || isAnyAiSuggestLoading}
-                className="flex items-center gap-2 ml-2"
+            <div
+                className="relative inline-block"
+                title={isButtonDisabled && isTitleMissing ? t("aiSuggestTooltip") : ""}
             >
-                {isLoading ? (
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                ) : (
-                    <Sparkles className="w-4 h-4" />
-                )}
-                AI Suggest
-            </Button>
+                <Button
+                    variant="outline"
+                    onClick={onClick}
+                    disabled={isButtonDisabled}
+                    className="flex items-center gap-2 ml-2"
+                >
+                    {isLoading ? (
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                        <Sparkles className="w-4 h-4" />
+                    )}
+                    {t("aiSuggest")}
+                </Button>
+            </div>
         );
     }
 


### PR DESCRIPTION
This pull request introduces improvements to the AI suggestion feature in the document generation form, focusing on better user experience and internationalization. The main changes include adding localized strings for the AI suggestion button and tooltip, and updating the button logic to display a tooltip and disable itself when the document title is missing.

**Internationalization enhancements:**

* Added `aiSuggest` and `aiSuggestTooltip` strings to both `messages/en.json` and `messages/de.json` for English and German language support. [[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeR22-R23) [[2]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158R24-R25)

**User experience improvements:**

* Updated the `AISuggestButton` in `src/components/ropa-form.tsx` to:
  - Disable the button and show a tooltip if the document title is missing.
  - Use localized text for the button label and tooltip.
  - Wrap the button in a container that conditionally sets the tooltip.
  
  
  ---
NO HOVER - technically weird, will attempt later