### PR TITLE
feat: add tab change handler to reset generated document

### DIFF
--- a/src/app/[locale]/generate/page.tsx
+++ b/src/app/[locale]/generate/page.tsx
@@ -19,9 +19,13 @@ export default function Generate() {
         setIsLoaded(true);
     }, []);
 
+    const handleTabChange = (value: string) => {
+        setGeneratedDocument("");
+    };
+
     return (
         <main className="container mx-auto py-10 relative space-y-6 w-full">
-            <Tabs defaultValue="mode1" className="w-full">
+            <Tabs defaultValue="mode1" className="w-full" onValueChange={handleTabChange}>
                 <TabsList className={`mb-4 flex w-fit mx-auto transition-opacity duration-700 ${isLoaded ? 'opacity-100' : 'opacity-0'}`}>
                     <TabsTrigger value="mode1">{t("tabForm")}</TabsTrigger>
                     <TabsTrigger value="mode2">{t("tabExplain")}</TabsTrigger>


### PR DESCRIPTION
This pull request introduces a small improvement to the tab functionality in the `Generate` page. The change ensures that when the user switches tabs, the generated document is cleared, providing a more intuitive user experience.

* Added a `handleTabChange` function to reset the `generatedDocument` state when the tab is changed, and connected it to the `Tabs` component via the `onValueChange` prop. (`src/app/[locale]/generate/page.tsx`) ([src/app/[locale]/generate/page.tsxR22-R28](diffhunk://#diff-80affb30328bff28ff43837499a1b34eddd9f86087b83489908467f644f3f666R22-R28))