### PR TITLE
feat ropa-form: add toast notifications for AI suggestion feedback an…

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -267,9 +267,12 @@
       "retentionPeriods": "Geben Sie an, wie lange Sie personenbezogene Daten vor der Löschung aufbewahren. Definieren Sie Aufbewahrungsfristen basierend auf gesetzlichen Anforderungen, Geschäftsbedürfnissen oder bis zum Widerruf der Einwilligung.",
       "additionalInfo": "Fügen Sie zusätzliche Informationen hinzu, die für diese Verarbeitungstätigkeit relevant sind, wie besondere Sicherheitsmaßnahmen, Drittanbieter-Verarbeiter, internationale Datentransfers oder spezifische Compliance-Hinweise.",
       "generateDocument": "Wählen Sie Ihr KI-Modell und generieren Sie das finale VVT-Dokument. Das System erstellt aus allen bereitgestellten Informationen ein umfassendes, DSGVO-konformes Verzeichnis von Verarbeitungstätigkeiten."
-    }
+    },
+    "noSuggestionReturned": "Kein Vorschlag der KI gegeben.",
+    "noChangesDetected": "Keine Änderungen der KI erkannt.",
+    "appliedChanges": "Es wurde(n) {count} Änderung(en) vorgenommen.",
+    "aiSuggestionFailed": "KI Vorschlag fehlgeschlagen."
   },
-
   "Preview": {
     "generatedDocument": "Erstelltes Dokument",
     "edit": "Bearbeiten",

--- a/messages/en.json
+++ b/messages/en.json
@@ -265,7 +265,11 @@
       "retentionPeriods": "Specify how long you keep personal data before deletion. Define retention periods based on legal requirements, business needs, or until consent is withdrawn.",
       "additionalInfo": "Add any extra information relevant to this processing activity, such as special security measures, third-party processors, international data transfers, or specific compliance notes.",
       "generateDocument": "Choose your AI model and generate the final ROPA document. The system will compile all provided information into a comprehensive, GDPR-compliant record of processing activities."
-    }
+    },
+    "noSuggestionReturned": "No suggestion returned from the AI.",
+    "noChangesDetected": "No changes detected from AI suggestion.",
+    "appliedChanges": "Applied {count} change(s).",
+    "aiSuggestionFailed": "AI suggestion failed."
   },
   "Preview": {
     "generatedDocument": "Generated Document",


### PR DESCRIPTION
This pull request adds user feedback for AI suggestions in the ROPA form, improving clarity when suggestions are applied, unchanged, missing, or fail. It introduces a local toast notification system, a utility to count differences between old and new values, and updates both English and German translations for new status messages.

**User feedback and toast notifications:**

* Added a local toast system in `src/components/ropa-form.tsx` to display status messages for AI suggestions, including success, info, and error notifications. Toasts are shown for applied changes, unchanged suggestions, missing suggestions, and failures. [[1]](diffhunk://#diff-91e7bb83ac448a7b3b33e5cc862f357ec9afedfaa04541077bfe2ae91ff49d86R229-R275) [[2]](diffhunk://#diff-91e7bb83ac448a7b3b33e5cc862f357ec9afedfaa04541077bfe2ae91ff49d86R1066-R1074)
* Implemented a helper function to count primitive differences between old and new values, enabling more precise feedback on the number of changes applied by the AI.

**AI suggestion application logic:**

* Refactored the AI suggestion application logic in `src/components/ropa-form.tsx` to use the new toast system and difference counter. Now, users receive clear feedback for each field when suggestions are applied, unchanged, missing, or fail.

**Translations:**

* Added new translation keys and messages for AI suggestion feedback in both `messages/en.json` and `messages/de.json`, supporting the new toast notifications. [[1]](diffhunk://#diff-5d9e5048516ec2fe83ca06813e79c3b8b44c6c96294f25c7311db311e28eeaeeL268-R272) [[2]](diffhunk://#diff-b1568a668b09f52f4419c80df7ac8ba9d6aa7d8743b00760e6c2b7f0937d9158L270-R275)